### PR TITLE
AppVeyor versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/drlkrd4ftaou35j1/branch/master?svg=true)](https://ci.appveyor.com/project/JayBazuzi/valuetypeassertions/branch/master)
 
-
 # ValueTypeAssertions
 
 By "value type", I mean "a type that represents a value in some domain."
@@ -28,3 +27,7 @@ public void NtfsPathIsCaseInsensitive()
   ValueTypeAssertions.HasValueEquality(new NtfsPath("foo.txt"), new NtfsPath("FOO.TXT"));
 }
 ```
+
+# Acknowledgements
+
+99% of the ideas in this project came from other people. A big chunk came from [Brian Geihsler](https://gist.github.com/bgeihsgt).

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,9 @@ Minimum Marketable Features
 
 User stories on the current MMF
 ====
-- appveyor build versioning
-- appveyor publish nuget
 - travis-CI build (blocked on https://github.com/travis-ci/travis-ci/issues/5932)
+
+Engineering tasks on the current story
+====
+- shared build properties?
+

--- a/ValueTypeAssertions.sln
+++ b/ValueTypeAssertions.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		appveyor-official.yml = appveyor-official.yml
 		appveyor.yml = appveyor.yml
 		LICENSE.md = LICENSE.md
 		README.md = README.md

--- a/ValueTypeAssertions/Properties/AssemblyInfo.cs
+++ b/ValueTypeAssertions/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyDescription("Value Type Assertions")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.0.*")]
+[assembly: AssemblyInformationalVersion("0.0.0-test")]

--- a/ValueTypeAssertions/ValueTypeAssertions.csproj
+++ b/ValueTypeAssertions/ValueTypeAssertions.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="ValueTypeAssertions.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/appveyor-official.yml
+++ b/appveyor-official.yml
@@ -1,5 +1,8 @@
 version: 0.0.{build}
 image: Visual Studio 2015
+branches:
+  only:
+  - master
 environment:
   TreatWarningsAsErrors: true
 before_build:
@@ -13,4 +16,10 @@ assembly_info:
   patch: true
   file: AssemblyInfo.cs
   assembly_version: "{version}"
-  assembly_informational_version: "{version}-{branch}"
+  assembly_informational_version: "{version}-beta"
+deploy:
+  provider: NuGet
+  api_key:
+    secure: ohOHAKDLwiS46NIS3DEbwnX6Ggln9CXEe9EKjwVASiRT8Re33GkkHUr+fS/7uz8l
+  skip_symbols: false
+  artifact: /.*\.nupkg/


### PR DESCRIPTION
Let's start with version 0.
# Local builds
- Uses .NET automatic versioning
- NuGet Version ends in "-test"
# AppVeyor unofficial builds
- Runs on all new branches, pull requests, etc. as a prereq to merging to master
- Uses build version
- NuGet Version ends in the branch name
# AppVeyor official builds
- Only runs on master
- Uses build version
- NuGet Version ends in "-beta" (this will go away at some point)
- Automatically publishes to NuGet.org
