### PR TITLE
It's OK for ToString() to vary by case, even in case-insensitive types

### DIFF
--- a/ValueTypeAssertions.Tests/Correctly Implemented Types/CaseInsensitiveStringWithCaseSensitiveToString.cs
+++ b/ValueTypeAssertions.Tests/Correctly Implemented Types/CaseInsensitiveStringWithCaseSensitiveToString.cs
@@ -4,7 +4,7 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Bazuzi.ValueTypeAssertions.Tests.Incorrectly_Implemented_Types.ToString
+namespace Bazuzi.ValueTypeAssertions.Tests.Correctly_Implemented_Types
 {
 	[TestClass]
 	public class CaseInsensitiveStringWithCaseSensitiveToString
@@ -13,8 +13,7 @@ namespace Bazuzi.ValueTypeAssertions.Tests.Incorrectly_Implemented_Types.ToStrin
 		public void EqualValues()
 		{
 			((Action) (() => ValueTypeAssertions.HasValueEquality(new C("foo"), new C("FOO"))))
-				.ShouldThrow<AssertFailedException>()
-				.And.Message.Should().Contain("ToString()");
+				.ShouldNotThrow();
 		}
 
 		private class C

--- a/ValueTypeAssertions.Tests/ValueTypeAssertions.Tests.csproj
+++ b/ValueTypeAssertions.Tests/ValueTypeAssertions.Tests.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Correctly Implemented Types\BuiltinTypes.cs" />
+    <Compile Include="Correctly Implemented Types\CaseInsensitiveStringWithCaseSensitiveToString.cs" />
     <Compile Include="Correctly Implemented Types\EquatableClass.cs" />
     <Compile Include="Correctly Implemented Types\Class.cs" />
     <Compile Include="Correctly Implemented Types\EquatableStruct.cs" />
@@ -72,7 +73,6 @@
     <Compile Include="Incorrectly Implemented Types\GetHashCode\DefaultGetHashCode.cs" />
     <Compile Include="Incorrectly Implemented Types\GetHashCode\GetHashCodeAlwaysReturns0.cs" />
     <Compile Include="Incorrectly Implemented Types\ToString\ToStringIsMissingAMember.cs" />
-    <Compile Include="Incorrectly Implemented Types\ToString\CaseInsensitiveStringWithCaseSensitiveToString.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Incorrectly Implemented Types\GetHashCode\CaseInsensitiveStringWithCaseSensitiveGetHashCode.cs" />
   </ItemGroup>

--- a/ValueTypeAssertions/ValueTypeAssertions.cs
+++ b/ValueTypeAssertions/ValueTypeAssertions.cs
@@ -28,7 +28,7 @@ namespace Bazuzi.ValueTypeAssertions
 
 			((object) item).Equals(equalItem).Should().BeTrue("object.Equals()");
 
-			item.ToString().Should().Be(equalItem.ToString(), "ToString()");
+			item.ToString().ToUpperInvariant().Should().Be(equalItem.ToString().ToUpperInvariant(), "ToString()");
 
 			item.GetHashCode().Should().Be(equalItem.GetHashCode(), "GetHashCode()");
 


### PR DESCRIPTION
This is such a common case in the real world.
